### PR TITLE
feat: display sessions count for each day-tab in search-mode 

### DIFF
--- a/lib/common/widgets/session/sessions_tab_bar_view.dart
+++ b/lib/common/widgets/session/sessions_tab_bar_view.dart
@@ -76,9 +76,27 @@ class _SessionsTabBarViewState extends State<SessionsTabBarView> with SingleTick
             return TabBar(
               controller: _tabController,
               tabs: [
-                Tab(text: tabDateFormat.format(ConferenceMetadata.day1)),
-                Tab(text: tabDateFormat.format(ConferenceMetadata.day2)),
-                Tab(text: tabDateFormat.format(ConferenceMetadata.day3)),
+                Tab(
+                  text: _getTabText(
+                    dateText: tabDateFormat.format(ConferenceMetadata.day1),
+                    sessionsCount: widget.day1SessionsSortedByStartTime.length,
+                    isSearchMode: isSearchMode,
+                  ),
+                ),
+                Tab(
+                  text: _getTabText(
+                    dateText: tabDateFormat.format(ConferenceMetadata.day2),
+                    sessionsCount: widget.day2SessionsSortedByStartTime.length,
+                    isSearchMode: isSearchMode,
+                  ),
+                ),
+                Tab(
+                  text: _getTabText(
+                    dateText: tabDateFormat.format(ConferenceMetadata.day3),
+                    sessionsCount: widget.day3SessionsSortedByStartTime.length,
+                    isSearchMode: isSearchMode,
+                  ),
+                ),
               ],
             );
           },


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

READY

## Description

<!--- Describe your changes in detail -->

- With this PR, each day's tab on the "Sessions" tab would display the number of search results found for that day using the search term

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Design Changes

<!--- Screenshots, GIFs, videos, if any  -->

|Before|After|
|:-:|:-:|
|![image](https://github.com/rohan20/fluttercon/assets/8232573/435193f3-8fdd-4499-be67-bc7f214a3d47)|![image](https://github.com/rohan20/fluttercon/assets/8232573/9383ba42-ee00-42ad-88a8-0227bcd95f62)|
