### PR TITLE
fix: room name's text overflows in sessions' list item

### DIFF
--- a/lib/common/widgets/session/session_room.dart
+++ b/lib/common/widgets/session/session_room.dart
@@ -21,11 +21,13 @@ class SessionRoom extends StatelessWidget {
         children: [
           Icon(Icons.location_on, size: 16, color: Colors.grey.shade400),
           const SizedBox(width: 4),
-          Text(
-            roomName,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: Theme.of(context).textTheme.bodySmall,
+          Flexible(
+            child: Text(
+              roomName,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
           ),
         ],
       ),

--- a/lib/common/widgets/session/session_room.dart
+++ b/lib/common/widgets/session/session_room.dart
@@ -10,26 +10,28 @@ class SessionRoom extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-      decoration: BoxDecoration(
-        color: Colors.transparent,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: Colors.grey.shade800, width: 0.2),
-      ),
-      child: Row(
-        children: [
-          Icon(Icons.location_on, size: 16, color: Colors.grey.shade400),
-          const SizedBox(width: 4),
-          Flexible(
-            child: Text(
-              roomName,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: Theme.of(context).textTheme.bodySmall,
+    return Flexible(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        decoration: BoxDecoration(
+          color: Colors.transparent,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: Colors.grey.shade800, width: 0.2),
+        ),
+        child: Row(
+          children: [
+            Icon(Icons.location_on, size: 16, color: Colors.grey.shade400),
+            const SizedBox(width: 4),
+            Flexible(
+              child: Text(
+                roomName,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/common/widgets/session/session_room.dart
+++ b/lib/common/widgets/session/session_room.dart
@@ -23,6 +23,8 @@ class SessionRoom extends StatelessWidget {
           const SizedBox(width: 4),
           Text(
             roomName,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
             style: Theme.of(context).textTheme.bodySmall,
           ),
         ],

--- a/lib/common/widgets/session/session_room.dart
+++ b/lib/common/widgets/session/session_room.dart
@@ -19,6 +19,7 @@ class SessionRoom extends StatelessWidget {
           border: Border.all(color: Colors.grey.shade800, width: 0.2),
         ),
         child: Row(
+          mainAxisSize: MainAxisSize.min,
           children: [
             Icon(Icons.location_on, size: 16, color: Colors.grey.shade400),
             const SizedBox(width: 4),


### PR DESCRIPTION
## Status

READY

## Description

Fixes room name text from overflowing in case the room name is long

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Design Changes

|Before|After|
|:-:|:-:|
|![image](https://github.com/user-attachments/assets/95721f9e-e021-40ba-9f0c-0f026c8b34ca)|![image](https://github.com/user-attachments/assets/a4b97eb8-2801-47d4-a093-baa7f6319555)|
